### PR TITLE
Fix: Rename Mastodon bots to Fediverse bots

### DIFF
--- a/src/assets/data/tools.en.json
+++ b/src/assets/data/tools.en.json
@@ -24,9 +24,9 @@
     "category": "Official tools"
   },
   {
-    "name": "Mastodon bots",
+    "name": "Fediverse bots",
     "description": "Generate images via ActivityPub just by pinging the bots.",
-    "link": "https://github.com/Haidra-Org/mastodon-ai-horde-generate",
+    "link": "https://github.com/Haidra-Org/fediverse-ai-horde-generate",
     "category": "Official tools"
   },
   {


### PR DESCRIPTION
fixes #2 