### PR TITLE
Resync upstream for kudos transfer changes

### DIFF
--- a/src/app/pages/transfer/transfer.component.ts
+++ b/src/app/pages/transfer/transfer.component.ts
@@ -149,7 +149,7 @@ export class TransferComponent implements OnInit, OnDestroy {
 
       const id = Number(parts[1]);
       const user = await toPromise(this.aiHorde.getUserById(id));
-      this.form.patchValue({targetUserValidated: user !== null && targetUser === user.username});
+      this.form.patchValue({targetUserValidated: user !== null && targetUser.toLowerCase() === user.username.toLowerCase()});
     }));
 
     this.form.patchValue({

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -88,8 +88,8 @@
   "transfer.success": "The kudos have been successfully transferred!",
   "transfer.error": "There was an error while transferring the kudos, please try again later.",
   "transfer.too_many_kudos": "Eh, you don't have that many kudos",
-  "transfer.donate": "or donate them to one of the educator accounts:",
+  "transfer.donate": "or donate them to an educator account: ",
   "option.empty": "-- none --",
   "transfer.account.kudos_amount": "has {{amountFormatted}} kudos",
-  "educators.explanation": "An educator account provides teachers and educational institutions with access to AI Horde for generating AI images."
+  "educators.explanation": "Educator accounts are special accounts made available to teachers and educational institutions for classroom use of AI Horde."
 }


### PR DESCRIPTION
- The validation for username was case-sensitive. As the number after the `#` is the critical element, the name before it having the wrong case is not a major concern. Accordingly, I adjusted the check to check both as the lowercase version.
- A couple of very minor tweaks to the wording on the transfer page
